### PR TITLE
Add file locking

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 ansible
 beautifulsoup4
 black
+filelock
 mypy
 pytest
 pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ cryptography==38.0.3
     # via ansible-core
 exceptiongroup==1.0.4
     # via pytest
+filelock==3.9.0
+    # via -r requirements.in
 idna==3.4
     # via requests
 iniconfig==1.1.1

--- a/src/wacks4shop/wack.py
+++ b/src/wacks4shop/wack.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 from pathlib import Path
-from time import sleep
 
 from dotenv import load_dotenv
 from filelock import FileLock, Timeout
@@ -89,7 +88,6 @@ if __name__ == "__main__":
     try:
         lock = FileLock(LOCKFILE, timeout=5)
         with lock:
-            sleep(30)
             # create the database folder if it doesn't exit
             Path(DATABASE_DIR).mkdir(parents=True, exist_ok=True)
 
@@ -97,4 +95,4 @@ if __name__ == "__main__":
             main(db=wackabase, dry=args.dry)
             wackabase.write_success()
     except Timeout:
-        logger.info("Lock is acquired! Exiting.")
+        logger.info("Could not acquire lock! Exiting.")


### PR DESCRIPTION
Another way to sort out https://github.com/allisonking/wacks-by-warby/issues/12

Uses the [filelock](https://py-filelock.readthedocs.io/en/latest/index.html) lib so that we only have one instance running at a time

To test:
* Activate your virtual env
* `pip install -r requirements.txt`
* Run `PYTHONPATH=src python -m wacks4shop.wack --dry` in one terminal. It can be helpful to comment out the main functionality and instead put a `time.sleep(30)` instead
* Run it again in another terminal
* The second instance should say it couldn't grab the lock and exit
* The first instance should complete as normal