### PR TITLE
add limit 300 to new get num sales method

### DIFF
--- a/src/wacks4shop/shift4shop.py
+++ b/src/wacks4shop/shift4shop.py
@@ -138,13 +138,13 @@ class Shift4Shop:
         Examples include "limit", "orderstatus", "datestart"
         """
         not_completed_orders_response = self._request_orders(
-            {"orderstatus": INCOMPLETE_ORDER_STATUS, **additional_query_filters}
+            {"orderstatus": INCOMPLETE_ORDER_STATUS, "limit": 300, **additional_query_filters}
         )
         num_not_completed_orders = 0
         for order in not_completed_orders_response.json():
             num_not_completed_orders += len(order["OrderItemList"])
 
-        total_orders_response = self._request_orders(additional_query_filters)
+        total_orders_response = self._request_orders({"limit": 300, **additional_query_filters})
         num_total_orders = 0
         for order in total_orders_response.json():
             num_total_orders += len(order["OrderItemList"])
@@ -177,7 +177,7 @@ class Shift4Shop:
 if __name__ == "__main__":
     load_dotenv()
     shift = Shift4Shop(debug=True)
-    prev_num_sales = 1
-    timestamp = (datetime.utcnow() - timedelta(days=2)).strftime(SHIFT4SHOP_TIME_FORMAT)
-    response = shift.get_num_sales(timestamp, prev_num_sales)
-    print(response)
+    prev_num_sales = 0
+    timestamp = (datetime.now() - timedelta(days=1)).strftime("%m/%d/%Y %H:%M:%S")
+    num_sales = shift.get_num_sales(timestamp, 0)
+    print(num_sales)


### PR DESCRIPTION
There seems to be two bugs contributing to discord notifications reporting the wrong total number of items sold.
1) There's a default limit of 10 orders returned per request. We aren't specifying a limit when making the order search request in the new get_num_sales method so we're miscounting here. kudos to @allisonking  for figuring this out by printing out the total order count and comparing with postman to discover we were only getting 20 orders per day back
2) our legacy get_num_sales method to backfill may be flawed now because I think we're over 300 orders at this point (390 total). It turns out the number of orders grows quite a bit faster than expected since every cart counts as an order even if they don't check out


So I think we can fix the problem if we go in to the server and manually fix the number of orders we have saved
and then we can't rely on the legacy backfill method anymore.