### PR TITLE
Jz/fix sale timestamp square

### DIFF
--- a/src/wacks4shop/shift4shop.py
+++ b/src/wacks4shop/shift4shop.py
@@ -122,7 +122,7 @@ class Shift4Shop:
                         num_sold=item["ItemQuantity"],
                         datetime=order_date,
                         location=None,
-                        fallback_name=None,
+                        fallback_name=item["ItemDescription"].split("<br>")[0],
                     )
                 )
         # order sales by date

--- a/src/wacks4shop/shift4shop.py
+++ b/src/wacks4shop/shift4shop.py
@@ -122,6 +122,7 @@ class Shift4Shop:
                         num_sold=item["ItemQuantity"],
                         datetime=order_date,
                         location=None,
+                        fallback_name=None,
                     )
                 )
         # order sales by date

--- a/src/wacks4shop/wack.py
+++ b/src/wacks4shop/wack.py
@@ -44,6 +44,7 @@ def main(db: Wackabase, dry=False):
                 num_sold=s.num_sold,
                 datetime=None,
                 location=None,
+                fallback_name=None
             )
             for s in sales
         ]

--- a/src/wacks4shop/wack.py
+++ b/src/wacks4shop/wack.py
@@ -44,7 +44,7 @@ def main(db: Wackabase, dry=False):
                 num_sold=s.num_sold,
                 datetime=None,
                 location=None,
-                fallback_name=None
+                fallback_name=s.fallback_name
             )
             for s in sales
         ]

--- a/src/wacks4square/square.py
+++ b/src/wacks4square/square.py
@@ -79,7 +79,7 @@ class Square:
         end_at = datetime.utcnow().isoformat()
         # bump timestamp to get orders after this time
         timestamp = (
-            datetime.strptime(timestamp, SQUARE_TIME_FORMAT) + timedelta(minutes=1)
+            datetime.strptime(timestamp, SQUARE_TIME_FORMAT) + timedelta(seconds=1)
         ).isoformat()
 
         params = {

--- a/src/wacks4square/square.py
+++ b/src/wacks4square/square.py
@@ -124,7 +124,8 @@ class Square:
                 listing_id = item.get("catalog_object_id")
                 item_name = item.get("name", "")
                 # this is used as a fallback name for the sale if we don't find it by id in werbies.json
-                fallback_name = f'{item_name} ({item.get("variation_name", "")})'
+                variation = f"({item.get('variation_name')})" if item.get("variation_name") else ""
+                fallback_name = f'{item_name} {variation}'
                 if 'Fee' in item_name:
                     logger.info(f'skipping credit card service fee, item: {item}, order id: {order_id}')
                     continue

--- a/src/wacks4square/square.py
+++ b/src/wacks4square/square.py
@@ -121,13 +121,13 @@ class Square:
                 listing_id = item.get("catalog_object_id")
                 if not listing_id:
                     continue
-                created_at = order["created_at"]
+                sale_time = order["closed_at"]
                 # some have milliseconds and some do not so let's strip the milliseconds out
-                created_at = re.sub(r"\..+Z", "", created_at)
+                sale_time = re.sub(r"\..+Z", "", sale_time)
                 # remove Z at the end for consistency
-                created_at = created_at.replace("Z", "")
+                sale_time = sale_time.replace("Z", "")
                 try:
-                    sale_time = datetime.strptime(created_at, SQUARE_TIME_FORMAT)
+                    sale_time = datetime.strptime(sale_time, SQUARE_TIME_FORMAT)
                 except ValueError as e:
                     logger.exception(
                         f"error converting order timestamp for order: {order}, item: {item}"

--- a/src/wacks4square/wack.py
+++ b/src/wacks4square/wack.py
@@ -52,7 +52,9 @@ def main(db: Wackabase, dry=False):
             current_num_sales = square.get_num_sales_slow()
 
         logger.info(f"current num sales: {current_num_sales}")
-        announce_new_sales(discord, sales, current_num_sales, id_type="square")
+
+        # sales are by timestamp desc, so flip it in order to announce them from oldest to newest
+        announce_new_sales(discord, list(reversed(sales)), current_num_sales, id_type="square")
 
         # write out the most recent sale's date (results were sorted by closed at desc, so latest one is first one)
         latest_sale_timestamp = sales[0].datetime

--- a/src/wacksbywarby/models.py
+++ b/src/wacksbywarby/models.py
@@ -26,6 +26,7 @@ class Sale:
     num_sold: int
     datetime: Optional[datetime]
     location: Optional[str]
+    fallback_name: Optional[str]
 
 
 @dataclass

--- a/src/wacksbywarby/wack.py
+++ b/src/wacksbywarby/wack.py
@@ -132,7 +132,7 @@ def transform_diffs_to_sales(id_to_listing_diff: Dict[str, InventoryDiff]):
                 num_sold=prev_quantity - current_quantity,
                 datetime=None,
                 location=None,
-                fallback_name=None
+                fallback_name=listing.title
             )
         )
     return sales

--- a/src/wacksbywarby/wack.py
+++ b/src/wacksbywarby/wack.py
@@ -75,7 +75,7 @@ def announce_new_sales(
     if embeds:
         embeds.append(
             DiscordEmbed(
-                title=f"{num_total_sales} total sales. Great job Werby! 🎉",
+                title=f"[{id_type}] {num_total_sales} total sales. Great job Werby! 🎉",
                 color=15277667,  # LUMINOUS_VIVID_PINK
                 footer=None,
                 image=None,

--- a/src/wacksbywarby/wack.py
+++ b/src/wacksbywarby/wack.py
@@ -55,8 +55,8 @@ def announce_new_sales(
         # format and send the discord message
         sold_out = sale.quantity == 0
         quantity_message = f" ({sale.num_sold:.0f} of 'em)" if sale.num_sold > 1 else ""
-        location = f" from {sale.location} location " if sale.location else ""
-        message = f"🚨 New {name} Sale!{quantity_message} {location}🚨"
+        location = f" [@{sale.location}]" if sale.location else ""
+        message = f"🚨 New {name} Sale!{quantity_message}{location}🚨"
         embed = DiscordEmbed(
             title=message,
             image=DiscordImage(url=image_url),

--- a/src/wacksbywarby/wack.py
+++ b/src/wacksbywarby/wack.py
@@ -49,7 +49,8 @@ def announce_new_sales(
                 # discord wants a decimal number for color
                 color = int(embed_data.color.strip("#"), 16)
         else:
-            name = "Unknown"
+            # if there was any fallback info available about the sale use it, otherwise default to unknown
+            name = sale.fallback_name if sale.fallback_name else "Unknown"
             image_url = ""
             color = None
         # format and send the discord message
@@ -131,6 +132,7 @@ def transform_diffs_to_sales(id_to_listing_diff: Dict[str, InventoryDiff]):
                 num_sold=prev_quantity - current_quantity,
                 datetime=None,
                 location=None,
+                fallback_name=None
             )
         )
     return sales


### PR DESCRIPTION
Closes #23

- Add sale channel to discord message
- Fix square sale look back by using `closed_at` time for the timestamp rather than `created_at`