### PR TITLE
Square refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ DISCORD_DEBUG_WEBHOOK=xxx
 SHIFT4SHOP_PRIVATE_KEY=xxx
 SHIFT4SHOP_PUBLIC_KEY=xxx
 SHIFT4SHOP_SHOP_TOKEN=xxx
+
+# Square
+SQUARE_MAIN_LOCATION_ID=xxx
+SQUARE_BACKUP_LOCATION_ID=xxx
+SQUARE_CLIENT_ID=xxx
+SQUARE_CLIENT_SECRET=xxx
 ```
 
 To run:
@@ -39,6 +45,23 @@ PYTHONPATH=src python3 -m wacks4shop.ls
 # Square integration
 PYTHONPATH=src python3 -m wacks4square.wack
 ```
+
+### For square...
+
+You will also need an initial credentials file. You'll need to get the app authorized then paste your SquareCredentials in `data/wack4square/square_creds.json`. For example:
+
+```json
+{
+  "access_token": "xxx",
+  "refresh_token": "yyy",
+  "short_lived": false,
+  "expires_at": "2023-03-21T18:24:57Z",
+  "merchant_id": "xxx",
+  "token_type": "bearer"
+}
+```
+
+This file will be overwritten by the refresh flow whenever we need to refresh the token.
 
 ## Developer Setup
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ PYTHONPATH=src python3 -m wacks4shop.ls
 
 # Square integration
 PYTHONPATH=src python3 -m wacks4square.wack
+
+# List Square products
+PYTHONPATH=src python3 -m wacks4square.ls
+
+# Square refresh token
+PYTHONPATH=src python3 -m wacks4square.refresh
 ```
 
 ### For square...

--- a/src/wacks4square/constants.py
+++ b/src/wacks4square/constants.py
@@ -1,0 +1,5 @@
+DATABASE_DIR = "data/wack4square"
+LOCKFILE = "wacks4square.lock"
+
+# ex: 2023-03-07T04:32:14Z
+DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"

--- a/src/wacks4square/ls.py
+++ b/src/wacks4square/ls.py
@@ -2,17 +2,19 @@ import logging
 
 from dotenv import load_dotenv
 
+from wacks4square.constants import DATABASE_DIR
 from wacks4square.square import Square
+from wacksbywarby.db import Wackabase
 
 load_dotenv()
 
 logger = logging.getLogger("wacks4shop")
 
 
-def main():
+def main(db: Wackabase):
     logger.info("Querying for products...")
-
-    square = Square(debug=False)
+    creds = db.get_square_creds()
+    square = Square(credentials=creds, debug=False)
 
     square.request_all_products()
 
@@ -20,4 +22,6 @@ def main():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    main()
+    wackabase = Wackabase(DATABASE_DIR)
+
+    main(wackabase)

--- a/src/wacks4square/ls.py
+++ b/src/wacks4square/ls.py
@@ -8,7 +8,7 @@ from wacksbywarby.db import Wackabase
 
 load_dotenv()
 
-logger = logging.getLogger("wacks4shop")
+logger = logging.getLogger("wacks4square")
 
 
 def main(db: Wackabase):

--- a/src/wacks4square/refresh.py
+++ b/src/wacks4square/refresh.py
@@ -1,28 +1,43 @@
 import logging
+from datetime import datetime
 
 from dotenv import load_dotenv
 
+from wacks4square.constants import DATABASE_DIR
 from wacks4square.square import Square
+from wacksbywarby.db import Wackabase
+from wacksbywarby.models import SquareCredentials
 
 load_dotenv()
 
-logger = logging.getLogger("wacks4shop")
+logger = logging.getLogger("wacks4square")
+
+ACCEPTABLE_DAYS_UNTIL_REFRESH = 14
 
 
-def main():
+def main(db: Wackabase):
     logger.info("Checking if token refresh is needed...")
-    # TODO: read in the existing token file and check if the expiration is under a week away
+    creds = db.get_square_creds()
 
-    # if it is not, exit here
+    # check if it is time to refresh
+    expiration_date = creds.expires_at
+    if (expiration_date - datetime.now()).days > ACCEPTABLE_DAYS_UNTIL_REFRESH:
+        return
 
-    # if it is, request a new token from Square
-    square = Square(debug=False)
+    logger.info("Time to refresh! (expiration date was %s)", expiration_date)
+    # TODO: request a new token from Square
+    square = Square(credentials=creds, debug=False)
+    ## pseudo code
     # new_token = square.refresh_token
+    # new_creds = SquareCredentials.from_string(new_token)
 
-    # write the new token to the token file
+    ## write the new token to the token file
+    # db.write_square_creds(new_creds)
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    main()
+    db = Wackabase(DATABASE_DIR)
+
+    main(db)

--- a/src/wacks4square/refresh.py
+++ b/src/wacks4square/refresh.py
@@ -1,0 +1,28 @@
+import logging
+
+from dotenv import load_dotenv
+
+from wacks4square.square import Square
+
+load_dotenv()
+
+logger = logging.getLogger("wacks4shop")
+
+
+def main():
+    logger.info("Checking if token refresh is needed...")
+    # TODO: read in the existing token file and check if the expiration is under a week away
+
+    # if it is not, exit here
+
+    # if it is, request a new token from Square
+    square = Square(debug=False)
+    # new_token = square.refresh_token
+
+    # write the new token to the token file
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    main()

--- a/src/wacks4square/refresh.py
+++ b/src/wacks4square/refresh.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 logger = logging.getLogger("wacks4square")
 
-ACCEPTABLE_DAYS_UNTIL_REFRESH = 14
+ACCEPTABLE_DAYS_UNTIL_REFRESH = 21
 
 
 def main(db: Wackabase):

--- a/src/wacks4square/refresh.py
+++ b/src/wacks4square/refresh.py
@@ -25,14 +25,17 @@ def main(db: Wackabase):
         return
 
     logger.info("Time to refresh! (expiration date was %s)", expiration_date)
-    # TODO: request a new token from Square
+    # request a new token from square
     square = Square(credentials=creds, debug=False)
-    ## pseudo code
-    # new_token = square.refresh_token
-    # new_creds = SquareCredentials.from_string(new_token)
+    new_token = square.request_token()
+    if not new_token:
+        logger.error("Could not retrieve new token 🙀")
+        return
+    new_creds = SquareCredentials.from_string(new_token)
 
-    ## write the new token to the token file
-    # db.write_square_creds(new_creds)
+    # write the new token to the token file
+    db.write_square_creds(new_creds)
+    logger.info("Refresh succeeded 🎉")
 
 
 if __name__ == "__main__":

--- a/src/wacks4square/square.py
+++ b/src/wacks4square/square.py
@@ -8,7 +8,7 @@ import requests
 from dotenv import load_dotenv
 
 from wacksbywarby.constants import SQUARE_TIME_FORMAT
-from wacksbywarby.models import Sale
+from wacksbywarby.models import Sale, SquareCredentials
 
 logger = logging.getLogger("square")
 
@@ -23,8 +23,10 @@ LOCATION_ID_TO_NAME = {MAIN_LOCATION_ID: "Main", BACKUP_LOCATION_ID: "Backup"}
 
 
 class Square:
-    def __init__(self, debug=False) -> None:
-        self.access_token = os.getenv("SQUARE_ACCESS_TOKEN")
+    def __init__(self, credentials: SquareCredentials, debug=False) -> None:
+        self.credentials = credentials
+        # support env variables for now
+        self.access_token = credentials.access_token or os.getenv("SQUARE_ACCESS_TOKEN")
         self.headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",

--- a/src/wacks4square/tests/test_square.py
+++ b/src/wacks4square/tests/test_square.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+from wacksbywarby.db import Wackabase
+from wacksbywarby.models import SquareCredentials
+
+
+@pytest.fixture
+def square_token():
+    return '{"access_token": "xxx", "refresh_token": "yyy", "short_lived": false, "expires_at": "2023-03-07T04:32:14Z", "merchant_id": "zzz", "token_type": "bearer"}'
+
+
+@pytest.fixture
+def temp_database(tmp_path_factory: pytest.TempPathFactory):
+    return tmp_path_factory.mktemp("test_data")
+
+
+def test_square_creds_marshalling(square_token: str):
+    """Can marshall back and forth"""
+    creds = SquareCredentials.from_string(square_token)
+    # just make sure we can call a timestamp func on this to assert it's been
+    # successfully converted to a timestamp
+    creds.expires_at.isoformat()
+    as_string = creds.to_string()
+    assert as_string == square_token
+
+
+def test_square_creds_io(temp_database: Path, square_token: str):
+    """Can read and write square creds from a file"""
+    db = Wackabase(str(temp_database))
+    creds = SquareCredentials.from_string(square_token)
+    db.write_square_creds(creds)
+    read_creds = db.get_square_creds()
+    assert read_creds.to_string() == square_token

--- a/src/wacks4square/wack.py
+++ b/src/wacks4square/wack.py
@@ -6,14 +6,12 @@ from pathlib import Path
 from dotenv import load_dotenv
 from filelock import FileLock, Timeout
 
+from wacks4square.constants import DATABASE_DIR, LOCKFILE
 from wacks4square.square import Square
 from wacksbywarby.constants import SHIFT4SHOP_TIME_FORMAT, WACK_ERROR_SENTINEL
 from wacksbywarby.db import Wackabase
 from wacksbywarby.discord import Discord
 from wacksbywarby.wack import announce_new_sales
-
-DATABASE_DIR = "data/wack4square"
-LOCKFILE = "wacks4quare.lock"
 
 load_dotenv()
 
@@ -26,7 +24,8 @@ def main(db: Wackabase, dry=False):
         logger.debug("Dry run: %s", dry)
 
         discord = Discord(debug=dry)
-        square = Square(debug=dry)
+        square_creds = db.get_square_creds()
+        square = Square(credentials=square_creds, debug=dry)
 
         last_timestamp = db.get_timestamp()
         # stored in db with shift4shop format, but square requires RFC 3339 format so let's convert it

--- a/src/wacksbywarby/db.py
+++ b/src/wacksbywarby/db.py
@@ -4,10 +4,10 @@ import logging
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from wacksbywarby.constants import SHIFT4SHOP_TIME_FORMAT, WACK_ERROR_SENTINEL
-from wacksbywarby.models import Inventory
+from wacksbywarby.models import Inventory, SquareCredentials
 
 logger = logging.getLogger("db")
 
@@ -21,6 +21,7 @@ class Wackabase:
         self.last_success_path = data_path / "last_success.txt"
         self.num_sales_path = data_path / "num_sales.txt"
         self.timestamp_path = data_path / "timestamp.txt"
+        self.square_creds = data_path / "square_creds.json"
 
     def get_last_entry(self) -> Dict[str, Inventory]:
         """Returns an empty dictionary if the data file does not exist"""
@@ -78,3 +79,12 @@ class Wackabase:
                 return t
         except FileNotFoundError:
             return None
+
+    def write_square_creds(self, creds: SquareCredentials):
+        with open(self.square_creds, "w") as f:
+            f.write(creds.to_string())
+
+    def get_square_creds(self):
+        with open(self.square_creds, "r") as f:
+            creds = f.read()
+            return SquareCredentials.from_string(creds)

--- a/src/wacksbywarby/models.py
+++ b/src/wacksbywarby/models.py
@@ -1,6 +1,9 @@
+import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, List
+from typing import List, Optional
+
+from wacks4square.constants import DATETIME_FMT as SQUARE_DATETIME_FMT
 
 
 @dataclass
@@ -56,3 +59,28 @@ class DiscordEmbed:
     color: Optional[int]
     image: Optional[DiscordImage]
     footer: Optional[DiscordFooter]
+
+
+@dataclass
+class SquareCredentials:
+    access_token: str
+    refresh_token: str
+    short_lived: bool
+    expires_at: datetime
+    merchant_id: str
+    token_type: str
+
+    @classmethod
+    def from_string(cls, string: str):
+        data: dict = json.loads(string)
+        data["expires_at"] = datetime.strptime(data["expires_at"], SQUARE_DATETIME_FMT)
+        return cls(**data)
+
+    def to_string(self):
+        def prepare(x: SquareCredentials):
+            as_dict = x.__dict__
+            # convert the pesky timestamp
+            as_dict["expires_at"] = datetime.strftime(x.expires_at, SQUARE_DATETIME_FMT)
+            return as_dict
+
+        return json.dumps(self, default=prepare)


### PR DESCRIPTION
Before deploying this, make sure to add an initial credential file in `data/wack4square/square_creds.json`

Changes:
* Add the token to the db
* Add SquareCredential class to marshal to and from the db
* Refactor the Square class to read its access token from the db instead of the environment variable
* Add oauth token call to Square class
* Implement refresh flow
* Update readme
* tests
