### PR TITLE
Use waterline from latest order, regardless of status

### DIFF
--- a/src/wacks4shop/shift4shop.py
+++ b/src/wacks4shop/shift4shop.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 from dotenv import load_dotenv
@@ -60,7 +60,9 @@ class Shift4Shop:
         products = response.json()
         return products
 
-    def determine_sales(self, timestamp: Optional[str]) -> list[Shift4ShopSale]:
+    def determine_sales(
+        self, timestamp: Optional[str]
+    ) -> Tuple[list[Shift4ShopSale], Optional[str]]:
         """
         Query the Shift4Shop API for all orders since the given timestamp. Then transform these orders
         into a list of Shift4ShopSale objects. Manually dedupe incomplete orders from all orders using
@@ -78,14 +80,6 @@ class Shift4Shop:
         if timestamp:
             incomplete_orders_params["datestart"] = timestamp
         incomplete_orders_response = self._request_orders(incomplete_orders_params)
-        incomplete_order_ids = {
-            order["OrderID"] for order in incomplete_orders_response.json()
-        }
-        completed_orders = [
-            order
-            for order in all_orders_response.json()
-            if order["OrderID"] not in incomplete_order_ids
-        ]
 
         if not all_orders_response.ok or not incomplete_orders_response.ok:
             # when there are no new orders, this will 404. this will happen a lot, so we
@@ -102,7 +96,31 @@ class Shift4Shop:
                     incomplete_orders_response.status_code,
                     incomplete_orders_response.content,
                 )
-            return []
+            return ([], timestamp)
+
+        incomplete_orders = incomplete_orders_response.json()
+        all_orders_since_timestamp = all_orders_response.json()
+
+        # Grab the most recent timestamp from ALL sales as opposed to just completed sales
+        # This lets us keep the waterline not too far from the last sale in the event that
+        # there are a lot of incompleted sales. This is to solve a bug for when there are >300
+        # sales between waterlines, which makes us miss orders.
+        try:
+            most_recent_order_timestamp = sorted(
+                (incomplete_orders + all_orders_since_timestamp),
+                key=lambda x: x["OrderDate"],
+                reverse=True,
+            )[0]["OrderDate"]
+        except IndexError:
+            # if we can't find anything, use the timestamp we were given
+            most_recent_order_timestamp = timestamp
+
+        incomplete_order_ids = {order["OrderID"] for order in incomplete_orders}
+        completed_orders = [
+            order
+            for order in all_orders_since_timestamp
+            if order["OrderID"] not in incomplete_order_ids
+        ]
 
         sales: list[Shift4ShopSale] = []
         for order in completed_orders:
@@ -126,7 +144,7 @@ class Shift4Shop:
                 )
         # order sales by date
         ordered_sales = sorted(sales, key=lambda sale: sale.datetime)
-        return ordered_sales
+        return (ordered_sales, most_recent_order_timestamp)
 
     def _internal_get_num_sales(self, additional_query_filters: dict) -> int:
         """

--- a/src/wacks4shop/wack.py
+++ b/src/wacks4shop/wack.py
@@ -22,11 +22,7 @@ load_dotenv()
 logger = logging.getLogger("wacks4shop")
 
 
-def log_waterline(db: Wackabase, timestamp: Optional[str]):
-    if not timestamp:
-        logger.error("No timestamp, what's going on?")
-        return
-
+def log_waterline(db: Wackabase, timestamp: str):
     logger.info(f"writing latest sale time: {timestamp}")
     timestamp_as_datetime = datetime.strptime(timestamp, SHIFT4SHOP_ORDER_DATE_FORMAT)
     db.write_timestamp(timestamp_as_datetime)
@@ -109,7 +105,10 @@ if __name__ == "__main__":
 
             wackabase = Wackabase(DATABASE_DIR)
             waterline = main(db=wackabase, dry=args.dry)
-            log_waterline(wackabase, waterline)
+            if not waterline:
+                logger.error("No timestamp, what's going on?")
+            else:
+                log_waterline(wackabase, waterline)
             logger.info("done!")
     except Timeout:
         logger.info("Could not acquire lock! Exiting.")

--- a/werbies.json
+++ b/werbies.json
@@ -957,7 +957,7 @@
       "https://i.etsystatic.com/17523062/r/il/7a2ce5/2828485403/il_570xN.2828485403_8fbl.jpg",
       "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/43d7c22d-6b9c-4a70-86b4-4d5c68ed816c/deivzis-8993f4db-5cbc-48cd-b84f-082fa6c95577.png/v1/fill/w_558,h_350,strp/zagreus_and_cerberus_by_seyumei_deivzis-350t.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9ODA0IiwicGF0aCI6IlwvZlwvNDNkN2MyMmQtNmI5Yy00YTcwLTg2YjQtNGQ1YzY4ZWQ4MTZjXC9kZWl2emlzLTg5OTNmNGRiLTVjYmMtNDhjZC1iODRmLTA4MmZhNmM5NTU3Ny5wbmciLCJ3aWR0aCI6Ijw9MTI4MCJ9XV0sImF1ZCI6WyJ1cm46c2VydmljZTppbWFnZS5vcGVyYXRpb25zIl19.G2j_FBPoO5ZZmsY9nq53kH1xDdysEQ6WHatqKSh_XoI"
     ],
-    "shift4shop_id": 1
+    "shift4shop_id": 49
   },
   "1341837829": {
     "name": "Spy x Family",


### PR DESCRIPTION
Change the waterline date to be from the latest order, rather than the latest completed order